### PR TITLE
Convert turrets to hitscan with barrel pitch and burst audio

### DIFF
--- a/assets/audio/sfx/mg_1.wav
+++ b/assets/audio/sfx/mg_1.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:474a23102910735ac740291d9e6c99769d47bcbe76679bfb74d3b6c002b69341
+size 438966

--- a/src/combat.rs
+++ b/src/combat.rs
@@ -960,11 +960,9 @@ pub fn turret_hitscan_fire_system(
         .map(|cam_transform| cam_transform.translation)
         .unwrap_or(Vec3::new(0.0, 100.0, 100.0));
 
-    // Audio throttling (separate counters for MG vs Heavy)
+    // Audio throttling for heavy turret (MG uses per-burst audio instead)
     let mut shots_fired = 0;
-    let mut mg_shots_fired = 0;
     const MAX_AUDIO_PER_FRAME: usize = 5;
-    const MAX_MG_AUDIO_PER_FRAME: usize = 3;
 
     // Barrel positions
     let standard_barrel_positions = [
@@ -1226,8 +1224,11 @@ pub fn turret_hitscan_fire_system(
 
                     // === AUDIO ===
                     if is_mg {
-                        mg_shots_fired += 1;
-                        if mg_shots_fired <= MAX_MG_AUDIO_PER_FRAME {
+                        // Play burst sound once at start of each burst (not per-shot)
+                        let burst_just_started = mg_turret_opt.as_ref()
+                            .map(|mg| mg.shots_in_burst == 1)
+                            .unwrap_or(false);
+                        if burst_just_started {
                             let turret_pos = global_transform.translation();
                             let distance = turret_pos.distance(camera_position);
                             let volume = proximity_volume(distance, crate::constants::VOLUME_MG_TURRET);

--- a/src/combat.rs
+++ b/src/combat.rs
@@ -985,6 +985,10 @@ pub fn turret_hitscan_fire_system(
             } else if mg_turret.shots_in_burst >= mg_turret.max_burst_shots {
                 mg_turret.cooldown_timer = mg_turret.cooldown_duration;
                 can_fire = false;
+                // Stop burst audio when entering cooldown
+                if let Some(audio_entity) = mg_turret.burst_audio.take() {
+                    commands.entity(audio_entity).try_despawn();
+                }
             }
         }
 
@@ -1041,6 +1045,15 @@ pub fn turret_hitscan_fire_system(
             }
 
             // === FIRE AT TARGET ===
+            // No target: stop burst audio and reset counter
+            if combat_unit.current_target.is_none() {
+                if let Some(ref mut mg_turret) = mg_turret_opt {
+                    mg_turret.shots_in_burst = 0;
+                    if let Some(audio_entity) = mg_turret.burst_audio.take() {
+                        commands.entity(audio_entity).try_despawn();
+                    }
+                }
+            }
             if let Some(target_entity) = combat_unit.current_target {
                 // Get target position and movement state
                 let target_info_opt: Option<(Vec3, bool)> = all_droids_query.get(target_entity)
@@ -1224,19 +1237,30 @@ pub fn turret_hitscan_fire_system(
 
                     // === AUDIO ===
                     if is_mg {
-                        // Play burst sound once at start of each burst (not per-shot)
+                        // Play burst sound once at start of each burst, track entity to stop on idle
                         let burst_just_started = mg_turret_opt.as_ref()
                             .map(|mg| mg.shots_in_burst == 1)
                             .unwrap_or(false);
                         if burst_just_started {
+                            // Kill previous audio if still playing
+                            if let Some(ref mut mg_turret) = mg_turret_opt {
+                                if let Some(old_audio) = mg_turret.burst_audio.take() {
+                                    commands.entity(old_audio).try_despawn();
+                                }
+                            }
+
                             let turret_pos = global_transform.translation();
                             let distance = turret_pos.distance(camera_position);
                             let volume = proximity_volume(distance, crate::constants::VOLUME_MG_TURRET);
 
-                            commands.spawn((
+                            let audio_entity = commands.spawn((
                                 AudioPlayer::new(audio_assets.mg_sound.clone()),
                                 PlaybackSettings::DESPAWN.with_volume(bevy::audio::Volume::Linear(volume)),
-                            ));
+                            )).id();
+
+                            if let Some(ref mut mg_turret) = mg_turret_opt {
+                                mg_turret.burst_audio = Some(audio_entity);
+                            }
                         }
                     } else {
                         shots_fired += 1;

--- a/src/combat.rs
+++ b/src/combat.rs
@@ -985,10 +985,6 @@ pub fn turret_hitscan_fire_system(
             } else if mg_turret.shots_in_burst >= mg_turret.max_burst_shots {
                 mg_turret.cooldown_timer = mg_turret.cooldown_duration;
                 can_fire = false;
-                // Stop burst audio when entering cooldown
-                if let Some(audio_entity) = mg_turret.burst_audio.take() {
-                    commands.entity(audio_entity).try_despawn();
-                }
             }
         }
 
@@ -1045,13 +1041,9 @@ pub fn turret_hitscan_fire_system(
             }
 
             // === FIRE AT TARGET ===
-            // No target: stop burst audio and reset counter
             if combat_unit.current_target.is_none() {
                 if let Some(ref mut mg_turret) = mg_turret_opt {
                     mg_turret.shots_in_burst = 0;
-                    if let Some(audio_entity) = mg_turret.burst_audio.take() {
-                        commands.entity(audio_entity).try_despawn();
-                    }
                 }
             }
             if let Some(target_entity) = combat_unit.current_target {
@@ -1237,30 +1229,19 @@ pub fn turret_hitscan_fire_system(
 
                     // === AUDIO ===
                     if is_mg {
-                        // Play burst sound once at start of each burst, track entity to stop on idle
+                        // Play burst sound once at start of each burst (not per-shot)
                         let burst_just_started = mg_turret_opt.as_ref()
                             .map(|mg| mg.shots_in_burst == 1)
                             .unwrap_or(false);
                         if burst_just_started {
-                            // Kill previous audio if still playing
-                            if let Some(ref mut mg_turret) = mg_turret_opt {
-                                if let Some(old_audio) = mg_turret.burst_audio.take() {
-                                    commands.entity(old_audio).try_despawn();
-                                }
-                            }
-
                             let turret_pos = global_transform.translation();
                             let distance = turret_pos.distance(camera_position);
                             let volume = proximity_volume(distance, crate::constants::VOLUME_MG_TURRET);
 
-                            let audio_entity = commands.spawn((
+                            commands.spawn((
                                 AudioPlayer::new(audio_assets.mg_sound.clone()),
                                 PlaybackSettings::DESPAWN.with_volume(bevy::audio::Volume::Linear(volume)),
-                            )).id();
-
-                            if let Some(ref mut mg_turret) = mg_turret_opt {
-                                mg_turret.burst_audio = Some(audio_entity);
-                            }
+                            ));
                         }
                     } else {
                         shots_fired += 1;

--- a/src/combat.rs
+++ b/src/combat.rs
@@ -74,6 +74,15 @@ pub fn calculate_hit_chance(
     accuracy.clamp(ACCURACY_MIN, ACCURACY_MAX)
 }
 
+/// Pitch angle (radians) from the MG barrel pivot to a target, clamped to the
+/// barrel's articulation range. Used by BOTH the rotation system (visual barrel
+/// angle) and the firing system (muzzle position) so they can never diverge.
+fn mg_barrel_pitch(pivot_world: Vec3, target_pos: Vec3) -> f32 {
+    let to_target = target_pos - pivot_world;
+    let horizontal_dist = Vec2::new(to_target.x, to_target.z).length();
+    to_target.y.atan2(horizontal_dist).clamp(MG_BARREL_PITCH_MIN, MG_BARREL_PITCH_MAX)
+}
+
 /// Calculate range penalty using segment-based interpolation
 /// Returns penalty as a positive value (0.0 to RANGE_SEGMENT_2_PENALTY)
 pub fn calculate_range_penalty(distance: f32) -> f32 {
@@ -163,9 +172,6 @@ pub fn setup_laser_assets(
         ..default()
     });
 
-    // Standard laser mesh
-    let laser_mesh = meshes.add(Rectangle::new(LASER_WIDTH, LASER_LENGTH));
-
     // MG turret uses shorter bolts (60% length)
     let mg_laser_mesh = meshes.add(Rectangle::new(LASER_WIDTH, LASER_LENGTH * 0.6));
 
@@ -175,7 +181,6 @@ pub fn setup_laser_assets(
     commands.insert_resource(LaserAssets {
         team_a_material,
         team_b_material,
-        laser_mesh,
         mg_laser_mesh,
         hitscan_tracer_mesh,
     });
@@ -463,247 +468,6 @@ pub fn target_acquisition_system(
             }
 
             combat_unit.current_target = closest_enemy;
-        }
-    }
-}
-
-/// DEPRECATED: Turret projectile fire system
-/// Replaced by turret_hitscan_fire_system for instant hit detection
-/// Kept for reference only
-#[allow(dead_code)]
-pub fn auto_fire_system(
-    time: Res<Time>,
-    mut commands: Commands,
-    laser_assets: Res<LaserAssets>,
-    mut turret_query: Query<(&GlobalTransform, &Transform, &BattleDroid, &mut CombatUnit, &mut crate::types::TurretRotatingAssembly, Option<&mut crate::types::MgTurret>)>,
-    target_query: Query<&GlobalTransform, With<BattleDroid>>,
-    tower_target_query: Query<&GlobalTransform, With<UplinkTower>>,
-    all_units_query: Query<(Entity, &GlobalTransform, &BattleDroid)>,
-    all_towers_query: Query<(Entity, &GlobalTransform, &UplinkTower)>,
-    camera_query: Query<&Transform, (With<RtsCamera>, Without<LaserProjectile>)>,
-    audio_assets: Res<AudioAssets>,
-    heightmap: Option<Res<TerrainHeightmap>>,
-) {
-    let delta_time = time.delta_secs();
-    
-    // Get camera position for initial orientation
-    let camera_position = camera_query.single()
-        .map(|cam_transform| cam_transform.translation)
-        .unwrap_or(Vec3::new(0.0, 100.0, 100.0)); // Fallback position
-    
-    // Count shots fired this frame for audio throttling
-    // NOTE: Infantry firing is now handled by hitscan_fire_system
-    let mut shots_fired = 0;
-    let mut mg_shots_fired = 0; // Separate counter for MG (prioritized)
-    const MAX_AUDIO_PER_FRAME: usize = 5; // Limit concurrent audio to prevent spam
-    const MAX_MG_AUDIO_PER_FRAME: usize = 3; // Prioritized limit for MG turret
-
-    // Handle turret firing with barrel positions
-    // Standard turret barrel positions
-    let standard_barrel_positions = [
-        Vec3::new(-1.8, 1.5, -6.0), // Left barrel muzzle
-        Vec3::new(1.8, 1.5, -6.0),  // Right barrel muzzle
-    ];
-    
-    // MG turret barrel position (single center barrel)
-    let mg_barrel_positions = [
-        Vec3::new(0.0, 2.0, -7.4),
-    ];
-
-    for (global_transform, local_transform, droid, mut combat_unit, mut turret, mut mg_turret_opt) in turret_query.iter_mut() {
-        // Handle MG firing mode control
-        let mut can_fire = true;
-        if let Some(ref mut mg_turret) = mg_turret_opt {
-            if mg_turret.cooldown_timer > 0.0 {
-                mg_turret.cooldown_timer -= delta_time;
-                can_fire = false;
-                if mg_turret.cooldown_timer <= 0.0 {
-                    mg_turret.shots_in_burst = 0;
-                }
-            } else if mg_turret.shots_in_burst >= mg_turret.max_burst_shots {
-                mg_turret.cooldown_timer = mg_turret.cooldown_duration;
-                can_fire = false;
-            }
-        }
-
-        // Update auto fire timer
-        combat_unit.auto_fire_timer -= delta_time;
-
-        if can_fire && combat_unit.auto_fire_timer <= 0.0 {
-            // Handle target validation and rapid switching for MG turrets
-            let is_continuous_mode = mg_turret_opt.as_ref()
-                .map(|mg| mg.firing_mode == crate::types::FiringMode::Continuous)
-                .unwrap_or(false);
-
-            // Check if current target is dead
-            if combat_unit.current_target.is_some() {
-                if let Some(target_entity) = combat_unit.current_target {
-                    let target_exists = target_query.get(target_entity).is_ok() ||
-                                       tower_target_query.get(target_entity).is_ok();
-                    if !target_exists {
-                        combat_unit.current_target = None;
-                    }
-                }
-            }
-
-            // For continuous mode MG, immediately acquire new target if current is None
-            if is_continuous_mode && combat_unit.current_target.is_none() {
-                let shooter_pos = global_transform.translation();
-
-                // Find closest enemy in range
-                let mut closest_enemy: Option<(Entity, f32)> = None;
-
-                // Check all enemy units
-                for (target_entity, target_transform, target_droid) in all_units_query.iter() {
-                    if target_droid.team != droid.team {
-                        let distance = shooter_pos.distance(target_transform.translation());
-                        if distance <= TARGETING_RANGE {
-                            if let Some((_, min_dist)) = closest_enemy {
-                                if distance < min_dist {
-                                    closest_enemy = Some((target_entity, distance));
-                                }
-                            } else {
-                                closest_enemy = Some((target_entity, distance));
-                            }
-                        }
-                    }
-                }
-
-                // If no units found, check enemy towers
-                if closest_enemy.is_none() {
-                    for (target_entity, target_transform, target_tower) in all_towers_query.iter() {
-                        if target_tower.team != droid.team {
-                            let distance = shooter_pos.distance(target_transform.translation());
-                            if distance <= TARGETING_RANGE {
-                                if let Some((_, min_dist)) = closest_enemy {
-                                    if distance < min_dist {
-                                        closest_enemy = Some((target_entity, distance));
-                                    }
-                                } else {
-                                    closest_enemy = Some((target_entity, distance));
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Assign new target immediately
-                combat_unit.current_target = closest_enemy.map(|(entity, _)| entity);
-            }
-
-            // Get or keep target
-            if let Some(target_entity) = combat_unit.current_target {
-                // Double-check target still exists (critical for rapid-fire MG to avoid wasting shots)
-                let target_transform = target_query.get(target_entity)
-                    .or_else(|_| tower_target_query.get(target_entity));
-
-                if let Ok(target_transform) = target_transform {
-                    let is_mg = mg_turret_opt.is_some();
-
-                    // Check line of sight before firing (critical for Map 2 terrain blocking)
-                    let shooter_pos = global_transform.translation();
-                    let target_pos = target_transform.translation();
-                    if !has_line_of_sight(shooter_pos, target_pos, heightmap.as_deref()) {
-                        // Clear target if line of sight is blocked
-                        combat_unit.current_target = None;
-                        continue;
-                    }
-
-                    // Determine barrel configuration, fire rate, and laser speed
-                    let (barrel_positions, fire_interval, laser_speed) = if is_mg {
-                        (&mg_barrel_positions[..], 0.05, LASER_SPEED * 3.0) // MG: 20 shots/sec, 3x speed
-                    } else {
-                        (&standard_barrel_positions[..], AUTO_FIRE_INTERVAL, LASER_SPEED)
-                    };
-
-                    // Reset timer
-                    combat_unit.auto_fire_timer = fire_interval;
-
-                    // Use cached laser material (turrets are Team A = green)
-                    let laser_material = laser_assets.team_a_material.clone();
-
-                    // Use appropriate cached mesh based on turret type
-                    let laser_mesh = if is_mg {
-                        laser_assets.mg_laser_mesh.clone()
-                    } else {
-                        laser_assets.laser_mesh.clone()
-                    };
-
-                    // Get current barrel position in local space
-                    let local_barrel_pos = barrel_positions[turret.current_barrel_index % barrel_positions.len()];
-
-                    // Transform barrel position to world space using turret's rotation
-                    let world_barrel_offset = local_transform.rotation * local_barrel_pos;
-                    let firing_pos = global_transform.translation() + world_barrel_offset;
-
-                    // Aim at center of collision sphere (ground level, where collision detection happens)
-                    let target_pos = target_transform.translation();
-                    let direction = (target_pos - firing_pos).normalize();
-                    let velocity = direction * laser_speed;
-
-                    // Calculate proper initial orientation
-                    let laser_rotation = calculate_laser_orientation(velocity, firing_pos, camera_position);
-                    let laser_transform = Transform::from_translation(firing_pos)
-                        .with_rotation(laser_rotation);
-
-                    // Spawn laser
-                    commands.spawn((
-                        Mesh3d(laser_mesh),
-                        MeshMaterial3d(laser_material),
-                        laser_transform,
-                        LaserProjectile {
-                            velocity,
-                            lifetime: LASER_LIFETIME,
-                            team: droid.team,
-                            origin: firing_pos,
-                        },
-                    ));
-
-                    // Advance to next barrel
-                    turret.current_barrel_index = (turret.current_barrel_index + 1) % barrel_positions.len();
-
-                    // Increment MG burst counter (both modes track shots for pause timing)
-                    if let Some(ref mut mg_turret) = mg_turret_opt {
-                        mg_turret.shots_in_burst += 1;
-                    }
-
-                    // Play sound per bullet (MG sounds are prioritized with separate counter)
-                    if is_mg {
-                        mg_shots_fired += 1;
-                        if mg_shots_fired <= MAX_MG_AUDIO_PER_FRAME {
-                            // MG uses single bullet sound with distance-based volume
-                            let turret_pos = global_transform.translation();
-                            let distance = turret_pos.distance(camera_position);
-                            let volume = proximity_volume(distance, crate::constants::VOLUME_MG_TURRET);
-                            trace!("MG turret at {:?}, camera at {:?}, distance: {:.1}, volume: {:.3}",
-                                turret_pos, camera_position, distance, volume);
-
-                            commands.spawn((
-                                AudioPlayer::new(audio_assets.mg_sound.clone()),
-                                PlaybackSettings::DESPAWN.with_volume(bevy::audio::Volume::Linear(volume)),
-                            ));
-                        }
-                    } else {
-                        shots_fired += 1;
-                        if shots_fired <= MAX_AUDIO_PER_FRAME {
-                            // Standard turret uses random laser sound with proximity-based volume
-                            let mut rng = rand::thread_rng();
-                            let sound = audio_assets.get_random_laser_sound(&mut rng);
-
-                            let turret_pos = global_transform.translation();
-                            let distance = turret_pos.distance(camera_position);
-                            let volume = proximity_volume(distance, crate::constants::VOLUME_HEAVY_TURRET);
-                            trace!("Heavy turret at {:?}, camera at {:?}, distance: {:.1}, volume: {:.3}",
-                                turret_pos, camera_position, distance, volume);
-
-                            commands.spawn((
-                                AudioPlayer::new(sound),
-                                PlaybackSettings::DESPAWN.with_volume(bevy::audio::Volume::Linear(volume)),
-                            ));
-                        }
-                    }
-                }
-            }
         }
     }
 }
@@ -1081,25 +845,15 @@ pub fn turret_hitscan_fire_system(
                     // Calculate firing position from barrel
                     let firing_pos = if is_mg {
                         // MG turret: compute barrel muzzle position with pitch rotation
-                        // Barrel pivot is at Y=2.0, Z=-1.0 relative to assembly
-                        // Muzzle extends Z=-6.4 from pivot
                         let assembly_pos = global_transform.translation();
-                        let barrel_pivot_local = Vec3::new(0.0, 2.0, -1.0);
-                        let barrel_pivot_world = assembly_pos + local_transform.rotation * barrel_pivot_local;
-
-                        // Calculate pitch angle to target
-                        let to_target = target_pos - barrel_pivot_world;
-                        let horizontal_dist = Vec2::new(to_target.x, to_target.z).length();
-                        let vertical_dist = to_target.y;
-                        let pitch_angle = vertical_dist.atan2(horizontal_dist).clamp(-0.52, 0.26);
+                        let barrel_pivot_world = assembly_pos + local_transform.rotation * MG_BARREL_PIVOT;
+                        let pitch_angle = mg_barrel_pitch(barrel_pivot_world, target_pos);
 
                         // Compute muzzle position with pitch applied
-                        // Muzzle extends 6.4 units forward from pivot
                         let barrel_forward = local_transform.rotation * Vec3::NEG_Z;
                         let pitch_rotation = Quat::from_axis_angle(local_transform.rotation * Vec3::X, pitch_angle);
                         let pitched_forward = pitch_rotation * barrel_forward;
-                        let muzzle_offset = pitched_forward * 6.4;
-                        barrel_pivot_world + muzzle_offset
+                        barrel_pivot_world + pitched_forward * MG_BARREL_MUZZLE_LENGTH
                     } else {
                         // Heavy turret: use standard barrel positions
                         let local_barrel_pos = standard_barrel_positions[turret.current_barrel_index % standard_barrel_positions.len()];
@@ -1626,18 +1380,9 @@ pub fn turret_rotation_system(
                     if let Some(children) = children {
                         for child in children.iter() {
                             if let Ok(mut barrel_transform) = barrel_query.get_mut(child) {
-                                // Barrel pivot is at (0, 2.0, -1.0) relative to assembly
-                                // Must match the pivot used in turret_hitscan_fire_system
-                                let barrel_pivot_local = Vec3::new(0.0, 2.0, -1.0);
-                                let barrel_world_pos = turret_pos + turret_transform.rotation * barrel_pivot_local;
-                                let to_target = target_pos - barrel_world_pos;
-                                let horizontal_dist = Vec2::new(to_target.x, to_target.z).length();
-                                let vertical_dist = to_target.y;
-
-                                let pitch_angle = vertical_dist.atan2(horizontal_dist);
-                                let pitch_clamped = pitch_angle.clamp(-0.52, 0.26);
-
-                                let target_pitch = Quat::from_rotation_x(pitch_clamped);
+                                let barrel_world_pos = turret_pos + turret_transform.rotation * MG_BARREL_PIVOT;
+                                let pitch_angle = mg_barrel_pitch(barrel_world_pos, target_pos);
+                                let target_pitch = Quat::from_rotation_x(pitch_angle);
 
                                 barrel_transform.rotation = barrel_transform.rotation.slerp(
                                     target_pitch,

--- a/src/combat.rs
+++ b/src/combat.rs
@@ -514,39 +514,15 @@ pub fn auto_fire_system(
         // Handle MG firing mode control
         let mut can_fire = true;
         if let Some(ref mut mg_turret) = mg_turret_opt {
-            match mg_turret.firing_mode {
-                crate::types::FiringMode::Burst => {
-                    // Burst mode: fire fixed shots then cooldown
-                    if mg_turret.cooldown_timer > 0.0 {
-                        mg_turret.cooldown_timer -= delta_time;
-                        can_fire = false;
-
-                        // Reset burst counter when cooldown ends
-                        if mg_turret.cooldown_timer <= 0.0 {
-                            mg_turret.shots_in_burst = 0;
-                        }
-                    } else if mg_turret.shots_in_burst >= mg_turret.max_burst_shots {
-                        // Start cooldown
-                        mg_turret.cooldown_timer = mg_turret.cooldown_duration;
-                        can_fire = false;
-                    }
+            if mg_turret.cooldown_timer > 0.0 {
+                mg_turret.cooldown_timer -= delta_time;
+                can_fire = false;
+                if mg_turret.cooldown_timer <= 0.0 {
+                    mg_turret.shots_in_burst = 0;
                 }
-                crate::types::FiringMode::Continuous => {
-                    // Continuous mode: pause after max_burst_shots for cooling
-                    if mg_turret.cooldown_timer > 0.0 {
-                        mg_turret.cooldown_timer -= delta_time;
-                        can_fire = false;
-
-                        // Reset burst counter when cooldown ends
-                        if mg_turret.cooldown_timer <= 0.0 {
-                            mg_turret.shots_in_burst = 0;
-                        }
-                    } else if mg_turret.shots_in_burst >= mg_turret.max_burst_shots {
-                        // Start cooldown after firing max shots
-                        mg_turret.cooldown_timer = mg_turret.cooldown_duration;
-                        can_fire = false;
-                    }
-                }
+            } else if mg_turret.shots_in_burst >= mg_turret.max_burst_shots {
+                mg_turret.cooldown_timer = mg_turret.cooldown_duration;
+                can_fire = false;
             }
         }
 
@@ -1002,31 +978,15 @@ pub fn turret_hitscan_fire_system(
         // === MG FIRING MODE CONTROL ===
         let mut can_fire = true;
         if let Some(ref mut mg_turret) = mg_turret_opt {
-            match mg_turret.firing_mode {
-                crate::types::FiringMode::Burst => {
-                    if mg_turret.cooldown_timer > 0.0 {
-                        mg_turret.cooldown_timer -= delta_time;
-                        can_fire = false;
-                        if mg_turret.cooldown_timer <= 0.0 {
-                            mg_turret.shots_in_burst = 0;
-                        }
-                    } else if mg_turret.shots_in_burst >= mg_turret.max_burst_shots {
-                        mg_turret.cooldown_timer = mg_turret.cooldown_duration;
-                        can_fire = false;
-                    }
+            if mg_turret.cooldown_timer > 0.0 {
+                mg_turret.cooldown_timer -= delta_time;
+                can_fire = false;
+                if mg_turret.cooldown_timer <= 0.0 {
+                    mg_turret.shots_in_burst = 0;
                 }
-                crate::types::FiringMode::Continuous => {
-                    if mg_turret.cooldown_timer > 0.0 {
-                        mg_turret.cooldown_timer -= delta_time;
-                        can_fire = false;
-                        if mg_turret.cooldown_timer <= 0.0 {
-                            mg_turret.shots_in_burst = 0;
-                        }
-                    } else if mg_turret.shots_in_burst >= mg_turret.max_burst_shots {
-                        mg_turret.cooldown_timer = mg_turret.cooldown_duration;
-                        can_fire = false;
-                    }
-                }
+            } else if mg_turret.shots_in_burst >= mg_turret.max_burst_shots {
+                mg_turret.cooldown_timer = mg_turret.cooldown_duration;
+                can_fire = false;
             }
         }
 

--- a/src/combat.rs
+++ b/src/combat.rs
@@ -932,6 +932,7 @@ pub fn turret_hitscan_fire_system(
     shield_config: Res<crate::shield::ShieldConfig>,
     mut squad_manager: ResMut<SquadManager>,
     mut turret_query: Query<(
+        Entity,
         &GlobalTransform,
         &Transform,
         &BattleDroid,
@@ -972,7 +973,7 @@ pub fn turret_hitscan_fire_system(
     // Note: MG barrel position is now computed dynamically with pitch rotation
     // See the firing_pos calculation for MG turrets below
 
-    for (global_transform, local_transform, droid, mut combat_unit, mut turret, mut mg_turret_opt) in turret_query.iter_mut() {
+    for (turret_entity, global_transform, local_transform, droid, mut combat_unit, mut turret, mut mg_turret_opt) in turret_query.iter_mut() {
         // === MG FIRING MODE CONTROL ===
         let mut can_fire = true;
         if let Some(ref mut mg_turret) = mg_turret_opt {
@@ -1093,6 +1094,10 @@ pub fn turret_hitscan_fire_system(
                     // Check line of sight
                     if !has_line_of_sight(firing_pos, target_pos, heightmap.as_deref()) {
                         combat_unit.current_target = None;
+                        // Burst is interrupted: reset so the next burst retriggers its audio
+                        if let Some(ref mut mg_turret) = mg_turret_opt {
+                            mg_turret.shots_in_burst = 0;
+                        }
                         continue;
                     }
 
@@ -1241,6 +1246,10 @@ pub fn turret_hitscan_fire_system(
                             commands.spawn((
                                 AudioPlayer::new(audio_assets.mg_sound.clone()),
                                 PlaybackSettings::DESPAWN.with_volume(bevy::audio::Volume::Linear(volume)),
+                                crate::types::MgBurstAudio {
+                                    turret: turret_entity,
+                                    volume,
+                                },
                             ));
                         }
                     } else {
@@ -1260,6 +1269,56 @@ pub fn turret_hitscan_fire_system(
                     }
                 }
             }
+        }
+    }
+}
+
+/// How long an MG burst clip takes to fade out after the last bullet.
+/// Matches the fade-out baked into the tail of the clip itself.
+const MG_BURST_AUDIO_FADE_SECS: f32 = 0.25;
+
+/// Start fading out MG burst audio the moment its turret stops firing —
+/// burst complete (cooldown), target lost, LOS blocked, or turret destroyed.
+/// This keeps the clip's end synced to the last bullet no matter how the
+/// burst ended, without the hard cut of despawning mid-playback.
+pub fn mg_burst_audio_sync_system(
+    mut commands: Commands,
+    audio_query: Query<(Entity, &crate::types::MgBurstAudio), Without<crate::types::AudioFadeOut>>,
+    turret_query: Query<(&CombatUnit, &crate::types::MgTurret)>,
+) {
+    for (audio_entity, burst_audio) in audio_query.iter() {
+        // Turret gone (destroyed) counts as not firing
+        let still_firing = turret_query.get(burst_audio.turret)
+            .map(|(combat_unit, mg_turret)| {
+                combat_unit.current_target.is_some()
+                    && mg_turret.cooldown_timer <= 0.0
+                    && mg_turret.shots_in_burst > 0
+            })
+            .unwrap_or(false);
+
+        if !still_firing {
+            commands.entity(audio_entity).insert(crate::types::AudioFadeOut {
+                remaining: MG_BURST_AUDIO_FADE_SECS,
+                duration: MG_BURST_AUDIO_FADE_SECS,
+            });
+        }
+    }
+}
+
+/// Fade marked audio entities to silence, then despawn them.
+/// One-way: once AudioFadeOut is inserted the clip always dies.
+pub fn audio_fade_out_system(
+    mut commands: Commands,
+    time: Res<Time>,
+    mut audio_query: Query<(Entity, &crate::types::MgBurstAudio, &mut crate::types::AudioFadeOut, &mut AudioSink)>,
+) {
+    for (entity, burst_audio, mut fade, mut sink) in audio_query.iter_mut() {
+        fade.remaining -= time.delta_secs();
+        if fade.remaining <= 0.0 {
+            commands.entity(entity).try_despawn();
+        } else {
+            let t = fade.remaining / fade.duration;
+            sink.set_volume(bevy::audio::Volume::Linear(burst_audio.volume * t));
         }
     }
 }

--- a/src/combat.rs
+++ b/src/combat.rs
@@ -1552,23 +1552,19 @@ pub fn turret_rotation_system(
                     if let Some(children) = children {
                         for child in children.iter() {
                             if let Ok(mut barrel_transform) = barrel_query.get_mut(child) {
-                                // Calculate pitch angle from barrel pivot to target
-                                // Barrel pivot is at Y=3.0 (base 1.0 + assembly offset 2.0)
-                                let barrel_world_pos = turret_global_transform.translation() + Vec3::new(0.0, 3.0, 0.0);
+                                // Barrel pivot is at (0, 2.0, -1.0) relative to assembly
+                                // Must match the pivot used in turret_hitscan_fire_system
+                                let barrel_pivot_local = Vec3::new(0.0, 2.0, -1.0);
+                                let barrel_world_pos = turret_pos + turret_transform.rotation * barrel_pivot_local;
                                 let to_target = target_pos - barrel_world_pos;
                                 let horizontal_dist = Vec2::new(to_target.x, to_target.z).length();
                                 let vertical_dist = to_target.y;
 
-                                // Calculate pitch angle (positive when looking down because target is below)
                                 let pitch_angle = vertical_dist.atan2(horizontal_dist);
-
-                                // Clamp pitch to reasonable range (-30° to +15°)
                                 let pitch_clamped = pitch_angle.clamp(-0.52, 0.26);
 
-                                // Apply pitch as rotation around local X axis
                                 let target_pitch = Quat::from_rotation_x(pitch_clamped);
 
-                                // Smooth interpolation for barrel pitch
                                 barrel_transform.rotation = barrel_transform.rotation.slerp(
                                     target_pitch,
                                     rotation_speed * time.delta_secs()

--- a/src/combat.rs
+++ b/src/combat.rs
@@ -914,6 +914,7 @@ pub fn hitscan_fire_system(
                         commands.spawn((
                             AudioPlayer::new(sound),
                             PlaybackSettings::DESPAWN.with_volume(bevy::audio::Volume::Linear(volume)),
+                            crate::types::GunfireAudio { volume },
                         ));
                     }
                 }
@@ -972,6 +973,21 @@ pub fn turret_hitscan_fire_system(
     ];
     // Note: MG barrel position is now computed dynamically with pitch rotation
     // See the firing_pos calculation for MG turrets below
+
+    // MG turrets currently mid-burst (last frame's state), for loudness normalization:
+    // concurrent clips sum acoustically, so each clip is scaled by 1/sqrt(count) to keep
+    // perceived MG loudness constant whether 1 or 5 turrets are firing
+    let active_mg_bursts = turret_query.iter()
+        .filter(|(_, _, _, _, combat_unit, _, mg_turret_opt)| {
+            mg_turret_opt.as_ref()
+                .map(|mg| combat_unit.current_target.is_some()
+                    && mg.cooldown_timer <= 0.0
+                    && mg.shots_in_burst > 0)
+                .unwrap_or(false)
+        })
+        .count()
+        .max(1);
+    let mg_burst_volume_scale = 1.0 / (active_mg_bursts as f32).sqrt();
 
     for (turret_entity, global_transform, local_transform, droid, mut combat_unit, mut turret, mut mg_turret_opt) in turret_query.iter_mut() {
         // === MG FIRING MODE CONTROL ===
@@ -1241,7 +1257,10 @@ pub fn turret_hitscan_fire_system(
                         if burst_just_started {
                             let turret_pos = global_transform.translation();
                             let distance = turret_pos.distance(camera_position);
-                            let volume = proximity_volume(distance, crate::constants::VOLUME_MG_TURRET);
+                            let volume = proximity_volume(
+                                distance,
+                                crate::constants::VOLUME_MG_TURRET * mg_burst_volume_scale,
+                            );
 
                             commands.spawn((
                                 AudioPlayer::new(audio_assets.mg_sound.clone()),
@@ -1250,6 +1269,7 @@ pub fn turret_hitscan_fire_system(
                                     turret: turret_entity,
                                     volume,
                                 },
+                                crate::types::GunfireAudio { volume },
                             ));
                         }
                     } else {
@@ -1264,6 +1284,7 @@ pub fn turret_hitscan_fire_system(
                             commands.spawn((
                                 AudioPlayer::new(sound),
                                 PlaybackSettings::DESPAWN.with_volume(bevy::audio::Volume::Linear(volume)),
+                                crate::types::GunfireAudio { volume },
                             ));
                         }
                     }
@@ -1302,6 +1323,34 @@ pub fn mg_burst_audio_sync_system(
                 duration: MG_BURST_AUDIO_FADE_SECS,
             });
         }
+    }
+}
+
+/// Duck the gunfire bed while an explosion plays, then ramp it back.
+/// One explosion clip can't compete with dozens of concurrent gunfire clips —
+/// masking, not volume, is why explosions sound small in a firefight.
+pub fn explosion_ducking_system(
+    time: Res<Time>,
+    mut ducking: ResMut<crate::types::ExplosionDucking>,
+    mut gunfire_query: Query<(&crate::types::GunfireAudio, &mut AudioSink), Without<crate::types::AudioFadeOut>>,
+) {
+    if ducking.timer <= 0.0 {
+        return;
+    }
+    ducking.timer -= time.delta_secs();
+
+    // Full duck, then ramp back to 1.0 over the release window so there's no pop
+    let factor = if ducking.timer <= 0.0 {
+        1.0
+    } else if ducking.timer >= crate::constants::EXPLOSION_DUCK_RELEASE {
+        crate::constants::EXPLOSION_DUCK_FACTOR
+    } else {
+        let t = ducking.timer / crate::constants::EXPLOSION_DUCK_RELEASE;
+        crate::constants::EXPLOSION_DUCK_FACTOR * t + 1.0 * (1.0 - t)
+    };
+
+    for (gunfire, mut sink) in gunfire_query.iter_mut() {
+        sink.set_volume(bevy::audio::Volume::Linear(gunfire.volume * factor));
     }
 }
 

--- a/src/combat.rs
+++ b/src/combat.rs
@@ -995,9 +995,8 @@ pub fn turret_hitscan_fire_system(
         Vec3::new(-1.8, 1.5, -6.0), // Left barrel
         Vec3::new(1.8, 1.5, -6.0),  // Right barrel
     ];
-    let mg_barrel_positions = [
-        Vec3::new(0.0, 2.0, -7.4),  // Single center barrel
-    ];
+    // Note: MG barrel position is now computed dynamically with pitch rotation
+    // See the firing_pos calculation for MG turrets below
 
     for (global_transform, local_transform, droid, mut combat_unit, mut turret, mut mg_turret_opt) in turret_query.iter_mut() {
         // === MG FIRING MODE CONTROL ===
@@ -1099,17 +1098,34 @@ pub fn turret_hitscan_fire_system(
                     let fire_interval = if is_mg { 0.05 } else { AUTO_FIRE_INTERVAL };
                     combat_unit.auto_fire_timer = fire_interval;
 
-                    // Get barrel positions
-                    let barrel_positions = if is_mg {
-                        &mg_barrel_positions[..]
-                    } else {
-                        &standard_barrel_positions[..]
-                    };
-
                     // Calculate firing position from barrel
-                    let local_barrel_pos = barrel_positions[turret.current_barrel_index % barrel_positions.len()];
-                    let world_barrel_offset = local_transform.rotation * local_barrel_pos;
-                    let firing_pos = global_transform.translation() + world_barrel_offset;
+                    let firing_pos = if is_mg {
+                        // MG turret: compute barrel muzzle position with pitch rotation
+                        // Barrel pivot is at Y=2.0, Z=-1.0 relative to assembly
+                        // Muzzle extends Z=-6.4 from pivot
+                        let assembly_pos = global_transform.translation();
+                        let barrel_pivot_local = Vec3::new(0.0, 2.0, -1.0);
+                        let barrel_pivot_world = assembly_pos + local_transform.rotation * barrel_pivot_local;
+
+                        // Calculate pitch angle to target
+                        let to_target = target_pos - barrel_pivot_world;
+                        let horizontal_dist = Vec2::new(to_target.x, to_target.z).length();
+                        let vertical_dist = to_target.y;
+                        let pitch_angle = vertical_dist.atan2(horizontal_dist).clamp(-0.52, 0.26);
+
+                        // Compute muzzle position with pitch applied
+                        // Muzzle extends 6.4 units forward from pivot
+                        let barrel_forward = local_transform.rotation * Vec3::NEG_Z;
+                        let pitch_rotation = Quat::from_axis_angle(local_transform.rotation * Vec3::X, pitch_angle);
+                        let pitched_forward = pitch_rotation * barrel_forward;
+                        let muzzle_offset = pitched_forward * 6.4;
+                        barrel_pivot_world + muzzle_offset
+                    } else {
+                        // Heavy turret: use standard barrel positions
+                        let local_barrel_pos = standard_barrel_positions[turret.current_barrel_index % standard_barrel_positions.len()];
+                        let world_barrel_offset = local_transform.rotation * local_barrel_pos;
+                        global_transform.translation() + world_barrel_offset
+                    };
 
                     // Check line of sight
                     if !has_line_of_sight(firing_pos, target_pos, heightmap.as_deref()) {
@@ -1239,8 +1255,9 @@ pub fn turret_hitscan_fire_system(
                         },
                     ));
 
-                    // Advance barrel index
-                    turret.current_barrel_index = (turret.current_barrel_index + 1) % barrel_positions.len();
+                    // Advance barrel index (MG has 1 barrel, Heavy has 2)
+                    let barrel_count = if is_mg { 1 } else { standard_barrel_positions.len() };
+                    turret.current_barrel_index = (turret.current_barrel_index + 1) % barrel_count;
 
                     // Increment MG burst counter
                     if let Some(ref mut mg_turret) = mg_turret_opt {
@@ -1503,35 +1520,63 @@ pub fn collision_detection_system(
     }
 }
 
-/// Turret rotation system - smoothly rotates turret assembly to face current target
+/// Turret rotation system - handles yaw (assembly) and pitch (barrel) rotation
+/// - TurretRotatingAssembly: horizontal rotation to face target
+/// - TurretBarrel: vertical rotation for MG turrets to aim up/down
 pub fn turret_rotation_system(
     time: Res<Time>,
-    mut turret_query: Query<(&mut Transform, &GlobalTransform, &CombatUnit, Option<&crate::types::MgTurret>), With<crate::types::TurretRotatingAssembly>>,
+    mut turret_query: Query<(&mut Transform, &GlobalTransform, &CombatUnit, Option<&crate::types::MgTurret>, Option<&Children>), With<crate::types::TurretRotatingAssembly>>,
     target_query: Query<&GlobalTransform, (With<BattleDroid>, Without<crate::types::TurretRotatingAssembly>)>,
+    mut barrel_query: Query<&mut Transform, (With<crate::types::TurretBarrel>, Without<crate::types::TurretRotatingAssembly>)>,
 ) {
-    for (mut turret_transform, turret_global_transform, combat_unit, mg_turret) in turret_query.iter_mut() {
+    for (mut turret_transform, turret_global_transform, combat_unit, mg_turret, children) in turret_query.iter_mut() {
         if let Some(target_entity) = combat_unit.current_target {
             if let Ok(target_global_transform) = target_query.get(target_entity) {
-                // Calculate direction to target (horizontal plane only)
-                // Use GlobalTransform to get world positions for direction calculation
                 let turret_pos = turret_global_transform.translation();
                 let target_pos = target_global_transform.translation();
 
-                // Flatten target position to horizontal plane (keep Y at turret's level)
+                // === YAW: Assembly rotation (horizontal) ===
                 let target_pos_flat = Vec3::new(target_pos.x, turret_pos.y, target_pos.z);
-
-                // Create target rotation using Transform's from_translation + looking_at
-                // This ensures the turret's -Z axis points at the target
                 let target_rotation = Transform::from_translation(turret_pos)
                     .looking_at(target_pos_flat, Vec3::Y)
                     .rotation;
 
-                // Smooth rotation interpolation
-                let rotation_speed = if mg_turret.is_some() { 5.0 } else { 3.0 }; // Faster for MG
+                let rotation_speed = if mg_turret.is_some() { 5.0 } else { 3.0 };
                 turret_transform.rotation = turret_transform.rotation.slerp(
                     target_rotation,
                     rotation_speed * time.delta_secs()
                 );
+
+                // === PITCH: Barrel rotation (vertical) - MG turret only ===
+                if mg_turret.is_some() {
+                    if let Some(children) = children {
+                        for child in children.iter() {
+                            if let Ok(mut barrel_transform) = barrel_query.get_mut(child) {
+                                // Calculate pitch angle from barrel pivot to target
+                                // Barrel pivot is at Y=3.0 (base 1.0 + assembly offset 2.0)
+                                let barrel_world_pos = turret_global_transform.translation() + Vec3::new(0.0, 3.0, 0.0);
+                                let to_target = target_pos - barrel_world_pos;
+                                let horizontal_dist = Vec2::new(to_target.x, to_target.z).length();
+                                let vertical_dist = to_target.y;
+
+                                // Calculate pitch angle (positive when looking down because target is below)
+                                let pitch_angle = vertical_dist.atan2(horizontal_dist);
+
+                                // Clamp pitch to reasonable range (-30° to +15°)
+                                let pitch_clamped = pitch_angle.clamp(-0.52, 0.26);
+
+                                // Apply pitch as rotation around local X axis
+                                let target_pitch = Quat::from_rotation_x(pitch_clamped);
+
+                                // Smooth interpolation for barrel pitch
+                                barrel_transform.rotation = barrel_transform.rotation.slerp(
+                                    target_pitch,
+                                    rotation_speed * time.delta_secs()
+                                );
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -42,6 +42,14 @@ pub const HITSCAN_TRACER_LENGTH: f32 = 4.0;   // Length of the tracer bolt visua
 pub const HITSCAN_TRACER_WIDTH: f32 = 0.25;   // Slightly wider than projectiles for visibility
 pub const HITSCAN_DAMAGE: f32 = 25.0;         // Damage per hitscan hit (buildings)
 
+// MG turret barrel geometry — shared by the spawn code (turrets.rs), the rotation
+// system, and the firing system. These MUST stay in sync or the visual barrel
+// angle diverges from the actual bullet trajectory.
+pub const MG_BARREL_PIVOT: bevy::math::Vec3 = bevy::math::Vec3::new(0.0, 2.0, -1.0); // Pivot relative to the rotating assembly
+pub const MG_BARREL_MUZZLE_LENGTH: f32 = 6.4;  // Muzzle distance from the pivot along the barrel
+pub const MG_BARREL_PITCH_MIN: f32 = -0.52;    // ~30° down
+pub const MG_BARREL_PITCH_MAX: f32 = 0.26;     // ~15° up
+
 // Spatial partitioning settings
 pub const GRID_CELL_SIZE: f32 = 5.0; // Size of each grid cell (smaller = fewer neighbors per cell)
 pub const GRID_SIZE: i32 = 200; // Number of cells per side (covers 1000x1000 area)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -91,12 +91,17 @@ pub const PERLIN_LACUNARITY: f64 = 2.0;             // Frequency multiplier per 
 
 // Audio volume settings
 pub const VOLUME_EXPLOSION: f32 = 0.5;              // Tower/unit explosion volume
-pub const VOLUME_TURRET_EXPLOSION: f32 = 0.3;      // Turret explosion volume (smaller than tower)
+pub const VOLUME_TURRET_EXPLOSION: f32 = 0.5;      // Turret explosion volume (plays over a ducked gunfire bed)
+
+// Explosion ducking: gunfire audio dips while an explosion plays so it isn't masked
+pub const EXPLOSION_DUCK_FACTOR: f32 = 0.25;   // Gunfire volume multiplier while ducked
+pub const EXPLOSION_DUCK_DURATION: f32 = 0.7;  // Total duck time in seconds
+pub const EXPLOSION_DUCK_RELEASE: f32 = 0.3;   // Ramp back to full volume over the last part
 #[allow(dead_code)]
 pub const VOLUME_LASER: f32 = 0.3;                  // Laser fire volume (droids and turrets)
 #[allow(dead_code)]
 pub const VOLUME_SHIELD_IMPACT: f32 = 0.4;          // Shield impact volume (moved to ShieldConfig, kept for reference)
-pub const VOLUME_MG_TURRET: f32 = 0.125;           // MG turret max volume (proximity-based)
+pub const VOLUME_MG_TURRET: f32 = 0.25;            // Target MG loudness; per-clip volume is divided by sqrt(concurrent bursts)
 pub const VOLUME_HEAVY_TURRET: f32 = 0.015;         // Heavy turret max volume (proximity-based)
 
 // Proximity-based audio attenuation

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -96,7 +96,7 @@ pub const VOLUME_TURRET_EXPLOSION: f32 = 0.3;      // Turret explosion volume (s
 pub const VOLUME_LASER: f32 = 0.3;                  // Laser fire volume (droids and turrets)
 #[allow(dead_code)]
 pub const VOLUME_SHIELD_IMPACT: f32 = 0.4;          // Shield impact volume (moved to ShieldConfig, kept for reference)
-pub const VOLUME_MG_TURRET: f32 = 0.1;             // MG turret max volume (proximity-based)
+pub const VOLUME_MG_TURRET: f32 = 0.125;           // MG turret max volume (proximity-based)
 pub const VOLUME_HEAVY_TURRET: f32 = 0.015;         // Heavy turret max volume (proximity-based)
 
 // Proximity-based audio attenuation

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,8 +137,8 @@ fn main() {
             // Combat systems
             target_acquisition_system,
             clear_blocked_targets_system, // Stuck prevention for AttackMove
-            hitscan_fire_system,      // Infantry use hitscan (instant damage + visual tracer)
-            auto_fire_system,         // Turrets still use projectiles
+            hitscan_fire_system,          // Infantry use hitscan (instant damage + visual tracer)
+            turret_hitscan_fire_system,   // Turrets now use hitscan too (no more wasted shots)
             volley_fire_system,
             update_projectiles,
             update_hitscan_tracers,   // Update visual tracers

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,7 @@ fn main() {
         .add_plugins(MaterialPlugin::<objective::ShieldBarMaterial>::default())
         .insert_resource(SpatialGrid::new())
         .insert_resource(SquadManager::new())
+        .insert_resource(types::ExplosionDucking::default())
         .insert_resource(GameState::default())
         .insert_resource(ExplosionDebugMode::default())
         .insert_resource(selection::SelectionState::default())
@@ -141,6 +142,7 @@ fn main() {
             turret_hitscan_fire_system,   // Turrets now use hitscan too (no more wasted shots)
             mg_burst_audio_sync_system.after(turret_hitscan_fire_system), // Fade burst audio when firing stops
             audio_fade_out_system,        // Apply audio fade-outs and despawn silent clips
+            explosion_ducking_system,     // Dip gunfire while explosions play
             volley_fire_system,
             update_projectiles,
             update_hitscan_tracers,   // Update visual tracers

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,8 @@ fn main() {
             clear_blocked_targets_system, // Stuck prevention for AttackMove
             hitscan_fire_system,          // Infantry use hitscan (instant damage + visual tracer)
             turret_hitscan_fire_system,   // Turrets now use hitscan too (no more wasted shots)
+            mg_burst_audio_sync_system.after(turret_hitscan_fire_system), // Fade burst audio when firing stops
+            audio_fade_out_system,        // Apply audio fade-outs and despawn silent clips
             volley_fire_system,
             update_projectiles,
             update_hitscan_tracers,   // Update visual tracers

--- a/src/procedural_meshes.rs
+++ b/src/procedural_meshes.rs
@@ -968,6 +968,90 @@ pub fn create_mg_turret_assembly_mesh(meshes: &mut ResMut<Assets<Mesh>>) -> Hand
         }
     }
 
+    // 1. Shoulder Swivel (Improved Connector)
+    // Turret ring (wide base)
+    add_cylinder(&mut vertices, &mut normals, &mut indices,
+        Vec3::new(0.0, 0.2, 0.0), 1.2, 0.4, 16);
+
+    // Hinge block (Box shape for pivot)
+    add_box(&mut vertices, &mut normals, &mut indices,
+        Vec3::new(0.0, 0.6, 0.0),
+        Vec3::new(1.0, 0.8, 1.0));
+
+    // 2. Arm Segment (Angled connection)
+    add_box(&mut vertices, &mut normals, &mut indices,
+        Vec3::new(0.0, 1.4, 0.5),
+        Vec3::new(0.6, 1.5, 0.6));
+
+    // 3. Weapon Housing (Main body)
+    add_box(&mut vertices, &mut normals, &mut indices,
+        Vec3::new(0.0, 2.0, 0.0),
+        Vec3::new(0.8, 0.8, 2.0));
+
+    // NOTE: Barrel is now a separate entity (see create_mg_turret_barrel_mesh)
+    // This allows independent pitch rotation
+
+    // 5. Cooling Fins (Thin boxes along housing sides)
+    // Moved slightly outward to avoid z-fighting with housing
+    let fin_count = 6;
+    for i in 0..fin_count {
+        let z_pos = 0.5 - (i as f32 * 0.25);
+        // Left fins
+        add_box(&mut vertices, &mut normals, &mut indices,
+            Vec3::new(-0.52, 2.0, z_pos),
+            Vec3::new(0.2, 0.6, 0.1));
+        // Right fins
+        add_box(&mut vertices, &mut normals, &mut indices,
+            Vec3::new(0.52, 2.0, z_pos),
+            Vec3::new(0.2, 0.6, 0.1));
+    }
+
+    // 7. Ammo Magazines (Side boxes)
+    // Left Magazine
+    add_box(&mut vertices, &mut normals, &mut indices,
+        Vec3::new(-0.95, 2.1, 0.0),
+        Vec3::new(0.5, 1.0, 1.4));
+    // Left Strut
+    add_box(&mut vertices, &mut normals, &mut indices,
+        Vec3::new(-0.6, 2.1, 0.0),
+        Vec3::new(0.3, 0.4, 0.8));
+
+    // Right Magazine
+    add_box(&mut vertices, &mut normals, &mut indices,
+        Vec3::new(0.95, 2.1, 0.0),
+        Vec3::new(0.5, 1.0, 1.4));
+    // Right Strut
+    add_box(&mut vertices, &mut normals, &mut indices,
+        Vec3::new(0.6, 2.1, 0.0),
+        Vec3::new(0.3, 0.4, 0.8));
+
+    // 6. Hydraulic Details (Optional small cylinders)
+    add_cylinder(&mut vertices, &mut normals, &mut indices,
+        Vec3::new(0.6, 1.0, 0.0), 0.1, 0.8, 8); // Right piston
+    add_cylinder(&mut vertices, &mut normals, &mut indices,
+        Vec3::new(-0.6, 1.0, 0.0), 0.1, 0.8, 8); // Left piston
+
+
+    // Add UVs
+    let uvs: Vec<[f32; 2]> = (0..vertices.len()).map(|_| [0.5, 0.5]).collect();
+
+    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+    mesh.insert_indices(Indices::U32(indices));
+
+    meshes.add(mesh)
+}
+
+/// Create procedural mesh for the MG turret barrel (separate entity for pitch rotation)
+/// Barrel origin is at the pivot point (weapon housing front) so pitch rotation works correctly
+pub fn create_mg_turret_barrel_mesh(meshes: &mut ResMut<Assets<Mesh>>) -> Handle<Mesh> {
+    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::RENDER_WORLD);
+
+    let mut vertices = Vec::new();
+    let mut normals = Vec::new();
+    let mut indices = Vec::new();
+
     // Helper: Add Cylinder (Z-aligned for barrels)
     fn add_z_cylinder(
         vertices: &mut Vec<[f32; 3]>,
@@ -1002,7 +1086,6 @@ pub fn create_mg_turret_assembly_mesh(meshes: &mut ResMut<Assets<Mesh>>) -> Hand
             let bn = side_base + next * 2;
             let tn = side_base + next * 2 + 1;
 
-            // REVERTED winding order to (b, tn, t) for Z-Axis Cylinder Outward faces
             indices.push(b); indices.push(tn); indices.push(t);
             indices.push(b); indices.push(bn); indices.push(tn);
         }
@@ -1050,87 +1133,30 @@ pub fn create_mg_turret_assembly_mesh(meshes: &mut ResMut<Assets<Mesh>>) -> Hand
         }
     }
 
-    // 1. Shoulder Swivel (Improved Connector)
-    // Turret ring (wide base)
-    add_cylinder(&mut vertices, &mut normals, &mut indices,
-        Vec3::new(0.0, 0.2, 0.0), 1.2, 0.4, 16);
+    // Barrel geometry - positions relative to pivot point at (0, 0, 0)
+    // The barrel will be parented to the assembly at the weapon housing front
+    // Original positions were at Y=2.0, Z=-1.2 to -7.4 relative to assembly
+    // Now centered at pivot: Y=0, Z starts at -0.2 (just past housing edge)
 
-    // Hinge block (Box shape for pivot)
-    add_box(&mut vertices, &mut normals, &mut indices,
-        Vec3::new(0.0, 0.6, 0.0),
-        Vec3::new(1.0, 0.8, 1.0));
-
-    // 2. Arm Segment (Angled connection)
-    add_box(&mut vertices, &mut normals, &mut indices,
-        Vec3::new(0.0, 1.4, 0.5),
-        Vec3::new(0.6, 1.5, 0.6));
-
-    // 3. Weapon Housing (Main body)
-    add_box(&mut vertices, &mut normals, &mut indices,
-        Vec3::new(0.0, 2.0, 0.0),
-        Vec3::new(0.8, 0.8, 2.0));
-
-    // 4. Barrel (Oerlikon 20mm Style - Elongated)
     // Stage 1: Base Connector/Shroud
     add_z_cylinder(&mut vertices, &mut normals, &mut indices,
-        Vec3::new(0.0, 2.0, -1.2),
+        Vec3::new(0.0, 0.0, -0.2),
         0.25, 0.4, 12);
 
     // Stage 2: Recoil Spring/Mechanism (Thicker section)
     add_z_cylinder(&mut vertices, &mut normals, &mut indices,
-        Vec3::new(0.0, 2.0, -2.2),
+        Vec3::new(0.0, 0.0, -1.2),
         0.18, 1.6, 12);
 
     // Stage 3: Main Long Barrel (Thin)
     add_z_cylinder(&mut vertices, &mut normals, &mut indices,
-        Vec3::new(0.0, 2.0, -5.0),
+        Vec3::new(0.0, 0.0, -4.0),
         0.10, 4.0, 12);
 
     // Stage 4: Muzzle Brake/Flash Hider
     add_z_cylinder(&mut vertices, &mut normals, &mut indices,
-        Vec3::new(0.0, 2.0, -7.2),
+        Vec3::new(0.0, 0.0, -6.2),
         0.14, 0.4, 12);
-
-    // 5. Cooling Fins (Thin boxes along housing sides)
-    // Moved slightly outward to avoid z-fighting with housing
-    let fin_count = 6;
-    for i in 0..fin_count {
-        let z_pos = 0.5 - (i as f32 * 0.25);
-        // Left fins
-        add_box(&mut vertices, &mut normals, &mut indices,
-            Vec3::new(-0.52, 2.0, z_pos),
-            Vec3::new(0.2, 0.6, 0.1));
-        // Right fins
-        add_box(&mut vertices, &mut normals, &mut indices,
-            Vec3::new(0.52, 2.0, z_pos),
-            Vec3::new(0.2, 0.6, 0.1));
-    }
-
-    // 7. Ammo Magazines (Side boxes)
-    // Left Magazine
-    add_box(&mut vertices, &mut normals, &mut indices,
-        Vec3::new(-0.95, 2.1, 0.0),
-        Vec3::new(0.5, 1.0, 1.4));
-    // Left Strut
-    add_box(&mut vertices, &mut normals, &mut indices,
-        Vec3::new(-0.6, 2.1, 0.0),
-        Vec3::new(0.3, 0.4, 0.8));
-
-    // Right Magazine
-    add_box(&mut vertices, &mut normals, &mut indices,
-        Vec3::new(0.95, 2.1, 0.0),
-        Vec3::new(0.5, 1.0, 1.4));
-    // Right Strut
-    add_box(&mut vertices, &mut normals, &mut indices,
-        Vec3::new(0.6, 2.1, 0.0),
-        Vec3::new(0.3, 0.4, 0.8));
-
-    // 6. Hydraulic Details (Optional small cylinders)
-    add_cylinder(&mut vertices, &mut normals, &mut indices,
-        Vec3::new(0.6, 1.0, 0.0), 0.1, 0.8, 8); // Right piston
-    add_cylinder(&mut vertices, &mut normals, &mut indices,
-        Vec3::new(-0.6, 1.0, 0.0), 0.1, 0.8, 8); // Left piston
-
 
     // Add UVs
     let uvs: Vec<[f32; 2]> = (0..vertices.len()).map(|_| [0.5, 0.5]).collect();

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -69,7 +69,7 @@ pub fn setup_scene(
         asset_server.load("audio/sfx/laser4.wav"),
     ];
     let explosion_sound = asset_server.load("audio/sfx/distant_explosion1.wav");
-    let mg_sound = asset_server.load("audio/sfx/mg_3_single.wav");
+    let mg_sound = asset_server.load("audio/sfx/mg_1.wav");
     let shield_impact_sound = asset_server.load("audio/sfx/shield_impact0.wav");
     let ground_explosion_sounds = vec![
         asset_server.load("audio/sfx/ground_explosion0.wav"),

--- a/src/turrets.rs
+++ b/src/turrets.rs
@@ -136,11 +136,12 @@ fn spawn_mg_turret_internal(
             current_barrel_index: 0,
         },
         MgTurret {
-            firing_mode: FiringMode::Continuous, // Start with Continuous mode for mowing down
+            firing_mode: FiringMode::Continuous,
             shots_in_burst: 0,
-            max_burst_shots: 45,   // 45 shots at 0.05s = ~2.25 seconds before pause (20 shots/sec)
-            cooldown_timer: 0.0,   // No cooldown initially
-            cooldown_duration: 1.5, // 1.5 second pause between bursts/sweeps
+            max_burst_shots: 40,
+            cooldown_timer: 0.0,
+            cooldown_duration: 1.5,
+            burst_audio: None,
         },
     )).id();
 

--- a/src/turrets.rs
+++ b/src/turrets.rs
@@ -8,7 +8,10 @@ use bevy::render::render_resource::{
 use bevy::render::alpha::AlphaMode;
 use crate::types::*;
 use crate::terrain::{TerrainHeightmap, MapSwitchEvent, MapPreset};
-use crate::procedural_meshes::*;
+use crate::procedural_meshes::{
+    create_mg_turret_base_mesh, create_mg_turret_assembly_mesh, create_mg_turret_barrel_mesh,
+    create_turret_base_mesh, create_turret_rotating_assembly_mesh,
+};
 
 /// MG turret health points
 pub const MG_TURRET_HEALTH: f32 = 10_000.0;
@@ -76,6 +79,7 @@ fn spawn_mg_turret_internal(
     // Create meshes
     let base_mesh = create_mg_turret_base_mesh(meshes);
     let assembly_mesh = create_mg_turret_assembly_mesh(meshes);
+    let barrel_mesh = create_mg_turret_barrel_mesh(meshes);
 
     // Create materials (Darker, more industrial)
     let base_material = materials.add(StandardMaterial {
@@ -92,6 +96,13 @@ fn spawn_mg_turret_internal(
         ..default()
     });
 
+    let barrel_material = materials.add(StandardMaterial {
+        base_color: Color::srgb(0.25, 0.28, 0.25), // Slightly darker for barrel
+        metallic: 0.95,
+        perceptual_roughness: 0.3,
+        ..default()
+    });
+
     // Spawn base entity (parent)
     let base_entity = commands.spawn((
         Mesh3d(base_mesh),
@@ -102,7 +113,7 @@ fn spawn_mg_turret_internal(
         Health::new(MG_TURRET_HEALTH),
     )).id();
 
-    // Spawn rotating assembly entity (child)
+    // Spawn rotating assembly entity (child of base) - handles YAW rotation
     let assembly_entity = commands.spawn((
         Mesh3d(assembly_mesh),
         MeshMaterial3d(gun_material),
@@ -133,8 +144,18 @@ fn spawn_mg_turret_internal(
         },
     )).id();
 
-    // Link child to parent
+    // Spawn barrel entity (child of assembly) - handles PITCH rotation
+    // Position: at weapon housing front (Y=2.0 relative to assembly, Z=-1.0 at housing edge)
+    let barrel_entity = commands.spawn((
+        Mesh3d(barrel_mesh),
+        MeshMaterial3d(barrel_material),
+        Transform::from_xyz(0.0, 2.0, -1.0), // Pivot point at weapon housing front
+        TurretBarrel,
+    )).id();
+
+    // Link entities: Base -> Assembly -> Barrel
     commands.entity(base_entity).add_children(&[assembly_entity]);
+    commands.entity(assembly_entity).add_children(&[barrel_entity]);
 
     base_entity
 }

--- a/src/turrets.rs
+++ b/src/turrets.rs
@@ -517,6 +517,7 @@ pub fn turret_death_system(
     mut commands: Commands,
     turret_query: Query<(Entity, &Transform, &Health), With<TurretBase>>,
     audio_assets: Res<crate::types::AudioAssets>,
+    mut ducking: ResMut<crate::types::ExplosionDucking>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut additive_materials: ResMut<Assets<crate::wfx_materials::AdditiveMaterial>>,
     mut smoke_materials: ResMut<Assets<crate::wfx_materials::SmokeScrollMaterial>>,
@@ -527,11 +528,17 @@ pub fn turret_death_system(
             let position = transform.translation;
             info!("Turret destroyed at {:?}", position);
 
-            // Play explosion sound (smaller volume than tower explosions)
+            // Play explosion sound. Use the punchy ground_explosion clips, not
+            // distant_explosion1: that clip is ~7dB quieter at the source (pre-muffled
+            // "distant" recording) and gets masked by MG fire at any volume setting.
+            let mut rng = rand::thread_rng();
             commands.spawn((
-                AudioPlayer::new(audio_assets.explosion_sound.clone()),
+                AudioPlayer::new(audio_assets.get_random_ground_explosion_sound(&mut rng)),
                 PlaybackSettings::DESPAWN.with_volume(bevy::audio::Volume::Linear(crate::constants::VOLUME_TURRET_EXPLOSION)),
             ));
+
+            // Duck the gunfire bed so the explosion reads through the mix
+            ducking.timer = crate::constants::EXPLOSION_DUCK_DURATION;
 
             // Spawn WFX billboard explosion (28 flames + 50 dot sparkles + 5 glow sparkles + 1 center glow)
             crate::wfx_spawn::spawn_turret_wfx_explosion(

--- a/src/turrets.rs
+++ b/src/turrets.rs
@@ -145,11 +145,12 @@ fn spawn_mg_turret_internal(
     )).id();
 
     // Spawn barrel entity (child of assembly) - handles PITCH rotation
-    // Position: at weapon housing front (Y=2.0 relative to assembly, Z=-1.0 at housing edge)
+    // Positioned at the weapon housing front; the rotation and firing systems
+    // both derive from the same constant so visuals and ballistics stay in sync
     let barrel_entity = commands.spawn((
         Mesh3d(barrel_mesh),
         MeshMaterial3d(barrel_material),
-        Transform::from_xyz(0.0, 2.0, -1.0), // Pivot point at weapon housing front
+        Transform::from_translation(crate::constants::MG_BARREL_PIVOT),
         TurretBarrel,
     )).id();
 

--- a/src/turrets.rs
+++ b/src/turrets.rs
@@ -136,12 +136,11 @@ fn spawn_mg_turret_internal(
             current_barrel_index: 0,
         },
         MgTurret {
-            firing_mode: FiringMode::Continuous,
+            firing_mode: FiringMode::Continuous, // Start with Continuous mode for mowing down
             shots_in_burst: 0,
-            max_burst_shots: 40,
-            cooldown_timer: 0.0,
-            cooldown_duration: 1.5,
-            burst_audio: None,
+            max_burst_shots: 40,   // 40 shots at 0.05s = ~2.0s, ends before the burst clip's fade-out
+            cooldown_timer: 0.0,   // No cooldown initially
+            cooldown_duration: 1.5, // 1.5 second pause between bursts/sweeps
         },
     )).id();
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -167,7 +167,6 @@ impl AudioAssets {
 pub struct LaserAssets {
     pub team_a_material: Handle<StandardMaterial>,
     pub team_b_material: Handle<StandardMaterial>,
-    pub laser_mesh: Handle<Mesh>,
     pub mg_laser_mesh: Handle<Mesh>,  // Shorter bolts for MG turret
     pub hitscan_tracer_mesh: Handle<Mesh>,  // Tracer bolt for hitscan weapons
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -355,6 +355,11 @@ pub struct TurretRotatingAssembly {
     pub current_barrel_index: usize, // 0-3 for four barrels in 2x2 arrangement
 }
 
+/// Marker component for MG turret barrel (child of TurretRotatingAssembly)
+/// The barrel entity handles pitch rotation while the assembly handles yaw
+#[derive(Component)]
+pub struct TurretBarrel;
+
 // Building collision component
 #[derive(Component)]
 pub struct BuildingCollider {

--- a/src/types.rs
+++ b/src/types.rs
@@ -413,6 +413,20 @@ pub struct MgBurstAudio {
     pub volume: f32,      // Spawn volume, used as the fade's starting point
 }
 
+/// Marker on any gunfire audio entity (infantry lasers, turret fire).
+/// Lets the explosion ducking system dip the whole gunfire bed at once.
+#[derive(Component)]
+pub struct GunfireAudio {
+    pub volume: f32,      // Spawn volume, restored when ducking releases
+}
+
+/// When an explosion fires, gunfire audio is ducked so the explosion
+/// punches through the mix instead of being masked by it.
+#[derive(Resource, Default)]
+pub struct ExplosionDucking {
+    pub timer: f32,       // Seconds of ducking remaining; 0 = inactive
+}
+
 /// One-way fade-out: once inserted, the audio entity fades to silence and despawns.
 #[derive(Component)]
 pub struct AudioFadeOut {

--- a/src/types.rs
+++ b/src/types.rs
@@ -405,6 +405,21 @@ pub struct MgTurret {
     pub cooldown_duration: f32,   // Cooldown duration (pause between bursts/sweeps)
 }
 
+/// Marker on an MG burst audio entity, linking it back to the turret that fired it.
+/// A sync system fades the clip out when the turret stops firing for any reason.
+#[derive(Component)]
+pub struct MgBurstAudio {
+    pub turret: Entity,   // The turret assembly entity (has MgTurret + CombatUnit)
+    pub volume: f32,      // Spawn volume, used as the fade's starting point
+}
+
+/// One-way fade-out: once inserted, the audio entity fades to silence and despawns.
+#[derive(Component)]
+pub struct AudioFadeOut {
+    pub remaining: f32,   // Seconds left in the fade
+    pub duration: f32,    // Total fade length
+}
+
 // PendingExplosion and ExplosionEffect moved to src/explosion_system.rs
 
 // Game state management

--- a/src/types.rs
+++ b/src/types.rs
@@ -403,6 +403,7 @@ pub struct MgTurret {
     pub max_burst_shots: u32,     // Max shots before pause (Burst: 40, Continuous: 40-50)
     pub cooldown_timer: f32,      // Cooldown timer
     pub cooldown_duration: f32,   // Cooldown duration (pause between bursts/sweeps)
+    pub burst_audio: Option<Entity>, // Active burst audio entity, despawned when firing stops
 }
 
 // PendingExplosion and ExplosionEffect moved to src/explosion_system.rs

--- a/src/types.rs
+++ b/src/types.rs
@@ -403,7 +403,6 @@ pub struct MgTurret {
     pub max_burst_shots: u32,     // Max shots before pause (Burst: 40, Continuous: 40-50)
     pub cooldown_timer: f32,      // Cooldown timer
     pub cooldown_duration: f32,   // Cooldown duration (pause between bursts/sweeps)
-    pub burst_audio: Option<Entity>, // Active burst audio entity, despawned when firing stops
 }
 
 // PendingExplosion and ExplosionEffect moved to src/explosion_system.rs


### PR DESCRIPTION
## Summary

Turrets (MG + heavy) now use the same instant-hit raycast system as infantry, eliminating the 3–4 wasted shots per kill that projectile travel time caused. On top of that: the MG barrel articulates up/down at targets, and turret audio was reworked from stacked per-shot clips into a state-synced burst-clip system with mix balancing.

## Changes

### Hitscan conversion
- New `turret_hitscan_fire_system`: instant raycast damage with cosmetic tracers (tracers kept for visual feedback, 500–600 u/s so they feel snappy)
- All accuracy modifiers still apply: 80% turret base accuracy, range falloff, target-movement penalty, high-ground bonus
- MG burst/cooldown mechanics preserved (40 shots @ 0.05s, 1.5s cooldown, continuous-mode instant retargeting)
- Deprecated `auto_fire_system` deleted (−236 lines)

### MG barrel pitch
- Barrel split out of the assembly mesh into its own entity: `TurretBase → TurretRotatingAssembly (yaw) → TurretBarrel (pitch, −30°…+15°)`
- Firing position derives the muzzle point through the same pitch math, so tracers leave the actual barrel tip
- Pivot/muzzle/clamp values centralized in `constants.rs` (`MG_BARREL_*`) and a shared `mg_barrel_pitch()` helper — the spawn, rotation, and firing code can no longer drift apart (that drift caused the barrel/bullet misalignment fixed mid-branch)

### Burst audio
- One `mg_1.wav` burst clip per firing cycle instead of up to 15 overlapping per-shot clips across turrets
- `mg_burst_audio_sync_system` watches each clip's turret and fades the clip out over 0.25s the moment firing stops for any reason (cooldown, target lost, LOS blocked, turret destroyed) — the clip's end always lands 0.25s after the last bullet, independent of framerate or clip length
- Equal-power loudness: per-clip volume = `0.25 / √(concurrent bursts)`, so 1 turret and 5 turrets read at the same perceived level
- Explosion audibility: turret deaths switched from the source-quiet `distant_explosion1.wav` (−19.8 dB mean) to the punchy `ground_explosion` clips, plus sidechain-style ducking — all gunfire audio (tagged `GunfireAudio`) dips to 25% for 0.7s when a turret dies so the explosion owns the mix instead of being masked by ~300 gunfire clips/sec

## Testing
- Verified on the map-3 defense scenario with 5 MG turrets: no tracer misses on moving infantry, barrel visually tracks target elevation and matches bullet trajectories
- Burst audio: end-of-burst sync, repeated target-loss/reacquire cycles, and solo vs stacked loudness all confirmed by ear
- Turret-death explosion clearly audible mid-firefight with ducking active
- `cargo build --profile opt-dev` clean, no warnings

## Notes for review
- Both hitscan fire systems sit at Bevy's 16-system-param limit; audio control deliberately uses marker components + small dedicated systems instead of threading more resources through them
- Possible follow-ups (not in this PR): trigger ducking from tower/artillery explosions, heavy-turret barrel pitch, splitting `turret_hitscan_fire_system` into smaller helpers
